### PR TITLE
Experimental new API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ Checkout the libraries listed below for real-world examples.
 
 * Classes for describing devices, registers and individual bit fields within registers in a fashion which maps closely with the datasheet
 * Value translation from real world numbers (such as `512ms`) to register values (such as `0b111`) and back again
-* Automatic generation of accessors for every BitField- add a `mode` field and you'll get `get_mode` and `set_mode` methods on your Register.
+* Read registers into a namedtuple of fields using `get`
+* Write multiple register fields in a transaction using `set` with keyword arguments
 * Support for treating multiple-bytes as a single value, or single register with multiple values
 
 # Built With i2cdevice
@@ -71,3 +72,25 @@ ltr559 = Device(I2C_ADDR, bit_width=8, registers=(
 ))
 ```
 
+## Reading Registers
+
+One configured a register's fields can be read into a namedtuple using the `get` method:
+
+```python
+register_values = ltr559.get('ALS_CONTROL')
+gain = register_values.gain
+sw_reset = register_values.sw_reset
+mode = register_values.mode
+```
+
+## Writing Registers
+
+The namedtuple returned from `get` is immutable and does not attempt to map values back to the hardware, in order to write one or more fields to a register you must use `set` with a keyword argument for each field:
+
+```python
+ltr559.set('ALS_CONTROL',
+           gain=4,
+           sw_reset=1)
+```
+
+This will read the register state from the device, update the bitfields accordingly and write the result back.

--- a/examples/ltr559.py
+++ b/examples/ltr559.py
@@ -129,28 +129,28 @@ ltr559 = Device(I2C_ADDR, i2c_dev=MockSMBus(0, default_registers={0x86: 0x92}), 
 
 
 if __name__ == "__main__":
-    with ltr559.get('PART_ID') as part_id:
-        assert part_id.part_number == 0x09
-        assert part_id.revision == 0x02
+    part_id = ltr559.get('PART_ID')
 
-    print(ltr559.get('PART_ID'))
+    assert part_id.part_number == 0x09
+    assert part_id.revision == 0x02
 
     print("""
 Found LTR-559.
 Part ID: 0x{:02x}
 Revision: 0x{:02x}
     """.format(
-        ltr559.get('PART_ID').part_number,
-        ltr559.get('PART_ID').revision
+        part_id.part_number,
+        part_id.revision
     ))
 
     print("""
 Soft Reset
     """)
-    ltr559.ALS_CONTROL.set_sw_reset(1)
+    ltr559.set('ALS_CONTROL', sw_reset=1)
+    ltr559.set('ALS_CONTROL', sw_reset=0)
     try:
         while True:
-            status = ltr559.ALS_CONTROL.get_sw_reset()
+            status = ltr559.get('ALS_CONTROL').sw_reset
             print("Status: {}".format(status))
             if status == 0:
                 break
@@ -159,58 +159,69 @@ Soft Reset
         pass
 
     print("Setting ALS threshold")
-    # Modifying the fields of this register without a "with" statement will trigger
-    # two successive read/modify/write operations. Use "with" to optimise these out.
-    ltr559.ALS_THRESHOLD.set_lower(0x0001)
-    ltr559.ALS_THRESHOLD.set_upper(0xFFEE)
+
+    # The `set` method can handle writes to multiple register fields
+    # specify each field value as a keyword argument
+    ltr559.set('ALS_THRESHOLD',
+                lower=0x0001,
+                upper=0xFFEE)
+
     print("{:08x}".format(ltr559.values['ALS_THRESHOLD']))
-    with ltr559.ALS_THRESHOLD as ALS_THRESHOLD:
-        print("LOWER: ", ALS_THRESHOLD.get_lower())
-        assert ALS_THRESHOLD.get_lower() == 0x0001
-        assert ALS_THRESHOLD.get_upper() == 0xFFEE
+
+    # The `get` method returns register values as an immutable
+    # namedtuple, and fields will be available as properties
+    # You must use `set` to write a register.
+    als_threshold = ltr559.get('ALS_THRESHOLD')
+    assert als_threshold.lower == 0x0001
+    assert als_threshold.upper == 0xFFEE
 
     print("Setting PS threshold")
-    ltr559.PS_THRESHOLD.set_lower(0)
-    ltr559.PS_THRESHOLD.set_upper(500)
+
+    ltr559.set('PS_THRESHOLD',
+               lower=0,
+               upper=500)
+
     print("{:08x}".format(ltr559.values['PS_THRESHOLD']))
-    with ltr559.PS_THRESHOLD as PS_THRESHOLD:
-        assert PS_THRESHOLD.get_lower() == 0
-        assert PS_THRESHOLD.get_upper() == 500
+
+    ps_threshold = ltr559.get('PS_THRESHOLD')
+    assert ps_threshold.lower == 0
+    assert ps_threshold.upper == 500
 
     print("Setting integration time and repeat rate")
-    ltr559.PS_MEAS_RATE.set_rate_ms(100)
-    ltr559.ALS_MEAS_RATE.set_integration_time_ms(50)
-    ltr559.ALS_MEAS_RATE.set_repeat_rate_ms(50)
-    with ltr559.ALS_MEAS_RATE as ALS_MEAS_RATE:
-        assert ALS_MEAS_RATE.get_integration_time_ms() == 50
-        assert ALS_MEAS_RATE.get_repeat_rate_ms() == 50
+    ltr559.set('PS_MEAS_RATE', rate_ms=100)
+    ltr559.set('ALS_MEAS_RATE',
+                integration_time_ms=50,
+                repeat_rate_ms=50)
+    
+    als_meas_rate = ltr559.get('ALS_MEAS_RATE')
+    assert als_meas_rate.integration_time_ms == 50
+    assert als_meas_rate.repeat_rate_ms == 50
 
     print("""
 Activating sensor
     """)
 
-    ltr559.INTERRUPT.set_mode('als+ps')
-    ltr559.PS_CONTROL.set_active(True)
-    ltr559.PS_CONTROL.set_saturation_indicator_enable(1)
+    ltr559.set('INTERRUPT', mode='als+ps')
+    ltr559.set('PS_CONTROL',
+               active=True,
+               saturation_indicator_enable=1)
 
-    with ltr559.PS_LED as PS_LED:
-        PS_LED.set_current_ma(50)
-        PS_LED.set_duty_cycle(1.0)
-        PS_LED.set_pulse_freq_khz(30)
-        PS_LED.write()  # *MUST* be called to write the value when in context mode
+    ltr559.set('PS_LED',
+               current_ma=50,
+               duty_cycle=1.0,
+               pulse_freq_khz=30)
 
-    ltr559.PS_N_PULSES.set_count(1)
+    ltr559.set('PS_N_PULSES', count=1)
 
-    with ltr559.ALS_CONTROL as ALS_CONTROL:
-        ALS_CONTROL.set_mode(1)
-        ALS_CONTROL.set_gain(4)
-        ALS_CONTROL.write()
+    ltr559.set('ALS_CONTROL',
+               mode=1,
+               gain=4)
 
-    with ltr559.ALS_CONTROL as ALS_CONTROL:
-        assert ALS_CONTROL.get_mode() == 1
-        assert ALS_CONTROL.get_gain() == 4
+    als_control = ltr559.get('ALS_CONTROL')
+    assert als_control.mode == 1
+    assert als_control.gain == 4
 
-    ltr559.PS_OFFSET.set_offset(69)
+    ltr559.set('PS_OFFSET', offset=69)
 
     als0 = 0
     als1 = 0
@@ -222,21 +233,17 @@ Activating sensor
 
     try:
         while True:
-            # By default any read from a register field will trigger a read from hardware
-            # and any write to a register field will trigger a write to hardware.
-            # Using the "with" statement overrides this behavior by locking the register
-            # value during the with context so that its value is only read once on context entry.
-            with ltr559.ALS_PS_STATUS as ALS_PS_STATUS:
-                ps_int = ALS_PS_STATUS.get_ps_interrupt() or ALS_PS_STATUS.get_ps_data()
-                als_int = ALS_PS_STATUS.get_als_interrupt() or ALS_PS_STATUS.get_als_data()
+            als_ps_status = ltr559.get('ALS_PS_STATUS')
+            ps_int = als_ps_status.ps_interrupt or als_ps_status.ps_data
+            als_int = als_ps_status.als_interrupt or als_ps_status.als_data
 
             if ps_int:
-                ps0 = ltr559.PS_DATA.get_ch0()
+                ps0 = ltr559.get('PS_DATA').ch0
 
             if als_int:
-                with ltr559.ALS_DATA as ALS_DATA:
-                    als0 = ALS_DATA.get_ch0()
-                    als1 = ALS_DATA.get_ch1()
+                als_data = ltr559.get('ALS_DATA')
+                als0 = als_data.ch0
+                als1 = als_data.ch1
 
                 ratio = 1000
                 if als0 + als0 > 0:

--- a/library/CHANGELOG.txt
+++ b/library/CHANGELOG.txt
@@ -1,3 +1,8 @@
+0.0.6
+-----
+
+* New API methods set and get
+
 0.0.5
 -----
 

--- a/library/README.rst
+++ b/library/README.rst
@@ -33,9 +33,9 @@ Features
    within registers in a fashion which maps closely with the datasheet
 -  Value translation from real world numbers (such as ``512ms``) to
    register values (such as ``0b111``) and back again
--  Automatic generation of accessors for every BitField- add a ``mode``
-   field and you'll get ``get_mode`` and ``set_mode`` methods on your
-   Register.
+-  Read registers into a namedtuple of fields using ``get``
+-  Write multiple register fields in a transaction using ``set`` with
+   keyword arguments
 -  Support for treating multiple-bytes as a single value, or single
    register with multiple values
 
@@ -93,6 +93,36 @@ keyword argument:
         ALS_CONTROL,
         ALS_DATA
     ))
+
+Reading Registers
+-----------------
+
+One configured a register's fields can be read into a namedtuple using
+the ``get`` method:
+
+.. code:: python
+
+    register_values = ltr559.get('ALS_CONTROL')
+    gain = register_values.gain
+    sw_reset = register_values.sw_reset
+    mode = register_values.mode
+
+Writing Registers
+-----------------
+
+The namedtuple returned from ``get`` is immutable and does not attempt
+to map values back to the hardware, in order to write one or more fields
+to a register you must use ``set`` with a keyword argument for each
+field:
+
+.. code:: python
+
+    ltr559.set('ALS_CONTROL',
+               gain=4,
+               sw_reset=1)
+
+This will read the register state from the device, update the bitfields
+accordingly and write the result back.
 
 .. |Build Status| image:: https://travis-ci.com/pimoroni/i2cdevice-python.svg?branch=master
    :target: https://travis-ci.com/pimoroni/i2cdevice-python

--- a/library/i2cdevice/__init__.py
+++ b/library/i2cdevice/__init__.py
@@ -1,6 +1,6 @@
 from collections import namedtuple
 
-__version__ = '0.0.5'
+__version__ = '0.0.6'
 
 
 def _mask_width(value, bit_width=8):
@@ -208,6 +208,13 @@ class Device(object):
         return self._i2c_address
 
     def set(self, register, **kwargs):
+        """Write one or more fields on a device register.
+
+        Accepts multiple keyword arguments, one for each field to write.
+
+        :param register: Name of register to write.
+
+        """
         self.read_register(register)
         self.lock_register(register)
         for field in kwargs.keys():

--- a/library/i2cdevice/__init__.py
+++ b/library/i2cdevice/__init__.py
@@ -85,7 +85,6 @@ class _RegisterProxy(object):
 
     """
     def __init__(self, device, register):
-        object.__init__(self)
         self.device = device
         self.register = register
 
@@ -128,8 +127,6 @@ class Register():
             self.fields[field.name] = field
 
         self.namedtuple = namedtuple(self.name, sorted(self.fields))
-        self.namedtuple.__enter__ = lambda self: self
-        self.namedtuple.__exit__ = lambda self, type, value, traceback: None
 
 
 class BitField():

--- a/library/i2cdevice/adapter.py
+++ b/library/i2cdevice/adapter.py
@@ -20,8 +20,10 @@ class LookupAdapter(Adapter):
         self.snap = snap
 
     def _decode(self, value):
-        index = list(self.lookup_table.values()).index(value)
-        return list(self.lookup_table.keys())[index]
+        for k, v in self.lookup_table.items():
+            if v == value:
+                return k
+        raise ValueError("{} not in lookup table".format(value))
 
     def _encode(self, value):
         if self.snap and type(value) in [int, float]:

--- a/library/setup.py
+++ b/library/setup.py
@@ -39,7 +39,7 @@ classifiers = ['Development Status :: 5 - Production/Stable',
 
 setup(
     name='i2cdevice',
-    version='0.0.5',
+    version='0.0.6',
     author='Philip Howard',
     author_email='phil@pimoroni.com',
     description="""Python DSL for interacting with SMBus-compatible i2c devices""",

--- a/library/tests/test_mocksmbus.py
+++ b/library/tests/test_mocksmbus.py
@@ -5,3 +5,9 @@ def test_smbus_io():
     bus = MockSMBus(1)
     bus.write_i2c_block_data(0x00, 0x00, [0xff, 0x00, 0xff])
     assert bus.read_i2c_block_data(0x00, 0x00, 3) == [0xff, 0x00, 0xff]
+
+
+def test_smbus_default_regs():
+    bus = MockSMBus(1, default_registers={0x60: 0x99, 0x88: 0x51})
+    assert bus.read_i2c_block_data(0x00, 0x60, 1) == [0x99]
+    assert bus.read_i2c_block_data(0x00, 0x88, 1) == [0x51]

--- a/library/tests/test_registerproxy.py
+++ b/library/tests/test_registerproxy.py
@@ -2,6 +2,7 @@ from i2cdevice import MockSMBus, Device, Register, BitField
 
 
 def test_register_proxy():
+    """This API pattern has been depricated in favour of set/get."""
     bus = MockSMBus(1)
     device = Device(0x00, i2c_dev=bus, registers=(
         Register('test', 0x00, fields=(

--- a/library/tests/test_set_and_get.py
+++ b/library/tests/test_set_and_get.py
@@ -25,9 +25,9 @@ def test_get_regs():
     ))
     device.set('test', test=0x66, monkey=0x77)
 
-    with device.get('test') as test:
-        assert test.test == 0x66
-        assert test.monkey == 0x77
+    reg = device.get('test')
+    reg.test == 0x66
+    reg.monkey == 0x77
 
     assert bus.regs[0] == 0x66
     assert bus.regs[1] == 0x77

--- a/library/tests/test_set_and_get.py
+++ b/library/tests/test_set_and_get.py
@@ -1,0 +1,33 @@
+from i2cdevice import MockSMBus, Device, Register, BitField
+
+
+def test_set_regs():
+    bus = MockSMBus(1)
+    device = Device(0x00, i2c_dev=bus, registers=(
+        Register('test', 0x00, fields=(
+            BitField('test', 0xFF),
+        )),
+    ))
+    device.set('test', test=123)
+
+    assert device.get('test').test == 123
+
+    assert bus.regs[0] == 123
+
+
+def test_get_regs():
+    bus = MockSMBus(1)
+    device = Device(0x00, i2c_dev=bus, registers=(
+        Register('test', 0x00, fields=(
+            BitField('test', 0xFF00),
+            BitField('monkey', 0x00FF),
+        ), bit_width=16),
+    ))
+    device.set('test', test=0x66, monkey=0x77)
+
+    with device.get('test') as test:
+        assert test.test == 0x66
+        assert test.monkey == 0x77
+
+    assert bus.regs[0] == 0x66
+    assert bus.regs[1] == 0x77

--- a/library/tox.ini
+++ b/library/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,35},qa
+envlist = py{27,35,36},qa
 skip_missing_interpreters = True
 
 [testenv]
@@ -22,3 +22,4 @@ deps =
 	check-manifest
 	flake8
 	rstcheck
+	pygments


### PR DESCRIPTION
This changeset introduces a new `set` and `get` method for i2cdevice. The purpose of these methods is to provide a less-bonkers approach to writing and reading values than the current (MicroPython incompatible) system of overriding `getattribute` and redirecting attribute lookups to our internal register dictionary.

# Get

The `get` method accepts a register name, reads the register and returns a namedtuple of all the available fields. These changes turn accessing multiple registers from:

```python
with device.REGISTER_NAME as REGISTER_NAME:
    status = REGISTER_NAME.get_status()
    interrupt = REGISTER_NAME.get_interrupt()
```

To:

```python
my_register= device.get('REGISTER_NAME')
my_register.status
my_register.interrupt
```

Note: It is important to understand that `my_register` is, at this point, a stateless `namedtuple` that's disconnected from the hardware. If it's a non-volatile register (IE: it never changes) then you can keep this object for the lifetime of your program. If you want to read it again (in the case of a volatile register) then you must call `device.get('REGISTER_NAME')` again.

# Set

Set cleans up the current conflation of `read` and `write` whereupon using this pattern:

```python
with device.REGISTER_NAME as REGISTER_NAME:
    REGISTER_NAME.set_status(status)
    REGISTER_NAME.set_interrupt(interrupt)
    REGISTER_NAME.write()
```

Could result in errors where the user (me, usually) forgets to call `write()` and their expected register changes are thus never written. `set` is explicit about the fact it's for writing to a register, and thus does not allow for this mistake, the above code would become:

```python
device.set('REGISTER_NAME',
                status=status,
                interrupt=interrupt)
```

This still allows for multi-register writes, but it is disambiguated from the `get` method and ensures your changes are *always* written to device. Under the hood this function reads the current register state, locks it, updates all the fields you have supplied, writes the changed register value(s) back to the device, and unlocks the register.

This change should come with a deadline for deprication of the existing, confusing and fragile API methods- removing the pattern `device.REGISTER_NAME.get_field_name()` in favour of `device.get('REGISTER_NAME').field_name`. This is a subtle aesthetic change on the face of it, but under the hood the latter method does not rely on any fragile and overzealous `getattribute` trickery.

@rabid-inventor and @septolum - since you've both worked with i2cdevice I'd appreciate your feedback here. All of our libraries can, and should be migrated over to this new style pretty easily and this will - hopefully (@septolum correct me if I'm wrong) facilitate MicroPython compatibility without having to use the ugly (and non read/write combining) `device.set_field('REGISTER_NAME', 'FIELD_NAME', value)` and `device.get_field('REGISTER_NAME', 'FIELD_NAME') approach.